### PR TITLE
Allow playback of local resources

### DIFF
--- a/android/src/main/java/com/greatdroid/reactnative/media/player/ReactMediaPlayerViewManager.java
+++ b/android/src/main/java/com/greatdroid/reactnative/media/player/ReactMediaPlayerViewManager.java
@@ -48,6 +48,10 @@ public class ReactMediaPlayerViewManager extends SimpleViewManager<ReactMediaPla
   @ReactProp(name = "src")
   public void setSrc(ReactMediaPlayerView view, @Nullable String uri) {
     Log.d(TAG, "setSrc...src=" + uri);
+    String resourcePrefix = "resource:";
+    if (uri.startsWith(resourcePrefix)) {
+        uri = "asset:///" + uri.substring(resourcePrefix.length());
+    }
     view.setUri(uri);
   }
 

--- a/ios/react-native-media-kit/RCTMediaPlayerView.m
+++ b/ios/react-native-media-kit/RCTMediaPlayerView.m
@@ -49,7 +49,17 @@
 
 - (void)initPlayerIfNeeded {
   if(!player) {
-    player = [AVPlayer playerWithURL:[NSURL URLWithString:self.src]];
+    NSURL *url;
+    NSString *resourcePrefix = @"resource:";
+    if ([self.src hasPrefix:resourcePrefix]) {
+      NSString *resource = [self.src substringFromIndex:[resourcePrefix length]];
+      NSBundle *mainBundle = [NSBundle mainBundle];
+      NSString *file = [mainBundle pathForResource:resource ofType:nil];
+      url = [NSURL fileURLWithPath:file];
+    } else {
+      url = [NSURL URLWithString:self.src];
+    }
+    player = [AVPlayer playerWithURL:url];
     [self setPlayer:player];
     [self addProgressObserver];
     [self addObservers];

--- a/library/MediaPlayerView.js
+++ b/library/MediaPlayerView.js
@@ -37,7 +37,7 @@ export default class MediaPlayerView extends React.Component {
   static propTypes = {
     ...RCTMediaPlayerView.propTypes,
     controls: PropTypes.bool,
-    poster: PropTypes.string
+    poster: PropTypes.any
   }
 
   static defaultProps = {
@@ -70,6 +70,10 @@ export default class MediaPlayerView extends React.Component {
   render() {
     let posterView;
     if(this.props.poster && this.state.width && this.state.height && this.state.showPoster) {
+      let posterSource = this.props.poster;
+      if (typeof(posterSource) === 'string') {
+        posterSource = {uri: posterSource};
+       }
       posterView = (
         <Image
           style={{
@@ -80,7 +84,7 @@ export default class MediaPlayerView extends React.Component {
           height: this.state.height,
           resizeMode: 'contain'
           }}
-          source={{uri: this.props.poster}}/>
+          source={posterSource}/>
       );
     }
 


### PR DESCRIPTION
I need playback of local resources. This pull adds support for this. You can refer to local resources for both the video and the poster like this:

```
<Video src="resource:video.mp4" poster={require('./foo.png')} .../>
```

You'll need to add the video file to your project:
- iOS: Simply add it as a resource in Xcode
- Android: Drop it in android/app/src/main/assets/video.mp4
