### PR TITLE
Controls slider disabled check is wrong

### DIFF
--- a/library/Controls.js
+++ b/library/Controls.js
@@ -157,7 +157,7 @@ export default class Controls extends React.Component {
             maximumValue={this.props.total}
             minimumValue={0}
             value={this.state.current}
-            disabled={this.props.total > 0}
+            disabled={this.props.total <= 0}
             tracks={tracks}
           />
 


### PR DESCRIPTION
The slider disabled check is wrong. Normally, you won't notice this, but, I was automatically hiding the controls after a few seconds of inactivity and then re-showing them again, and all of a sudden the slider was no longer working. This fixes that.
